### PR TITLE
Fixed backend dependencies

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -1424,4 +1424,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "3a369e1cf975d507ce4248724ae5cc41af84a5a59bcc4728db3ddfbca77025cd"
+content-hash = "9031b3ba256a72ae4b598e47d11bc83fdb5f78be5a5306e7f2896e97a16a5130"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,7 +26,7 @@ pydantic-settings = "2.1.0"
 gpiozero = "2.0"
 pigpio = "1.78"
 lgpio = "0.0.0.2"
-"RPi.GPIO" = "0.7.1"
+"RPi.GPIO" = {version = "0.7.1", markers= "sys_platform == 'linux'"}
 
 [tool.poetry.group.dev.dependencies]
 coverage = "7.4.0"


### PR DESCRIPTION
RPi.GPIO package did not build successfully on OSX. This needs to get installed on Raspberry Pi only.